### PR TITLE
Updated method visibility to be consistent with POST request methods

### DIFF
--- a/src/Endpoints/BootstrapEndpoint.php
+++ b/src/Endpoints/BootstrapEndpoint.php
@@ -108,7 +108,7 @@ class BootstrapEndpoint
      * @param $endpoint
      * @return mixed|\Psr\Http\Message\ResponseInterface
      */
-    private function getRequest($endpoint)
+    public function getRequest($endpoint)
     {
         return $this->getUrl(self::endpoint . $endpoint);
     }
@@ -119,7 +119,7 @@ class BootstrapEndpoint
      * @param $url
      * @return mixed|\Psr\Http\Message\ResponseInterface
      */
-    public function getUrl($url)
+    private function getUrl($url)
     {
         return $this->client()->get($url);
     }


### PR DESCRIPTION
The `getURL` and `getRequest` methods both have opposite visibilities to their counterpart `post` methods. 

This pull request fixes the inconsistency and switches `getURL` to `private` and `getRequest` to public to match the post methods, allowing us to call `getRequest` and hit endpoints that aren't built into the library (e.g. `GET /schools/revoked`).