### PR TITLE
Add support for regional domains

### DIFF
--- a/src/Endpoints/BootstrapEndpoint.php
+++ b/src/Endpoints/BootstrapEndpoint.php
@@ -10,8 +10,20 @@ class BootstrapEndpoint
 {
     /**
      * @var string
+     * @deprecated To allow for regional domains. Use getEndpoint instead
+     * @see BootstrapEndpoint::getEndpoint()
      */
     const endpoint = 'https://api.wonde.com/v1.0/';
+
+    /**
+     * @var string
+     */
+    public $domain = 'api.wonde.com';
+
+    /**
+     * @var string
+     */
+    public $version = 'v1.0';
 
     /**
      * @var string
@@ -110,7 +122,7 @@ class BootstrapEndpoint
      */
     private function getRequest($endpoint)
     {
-        return $this->getUrl(self::endpoint . $endpoint);
+        return $this->getUrl($this->getEndpoint() . $endpoint);
     }
 
     /**
@@ -166,7 +178,7 @@ class BootstrapEndpoint
      */
     public function postRequest($endpoint, $body = [])
     {
-        return $this->postUrl(self::endpoint . $endpoint, $body);
+        return $this->postUrl($this->getEndpoint() . $endpoint, $body);
     }
 
     /**
@@ -215,7 +227,7 @@ class BootstrapEndpoint
      */
     public function deleteRequest($endpoint, $body = [])
     {
-        return $this->deleteUrl(self::endpoint . $endpoint, $body);
+        return $this->deleteUrl($this->getEndpoint() . $endpoint, $body);
     }
 
     /**
@@ -228,7 +240,7 @@ class BootstrapEndpoint
     public function deleteRequestReturnBody($endpoint, $body = [])
     {
         /** @var Response $response */
-        $response = $this->deleteUrl(self::endpoint . $endpoint, $body);
+        $response = $this->deleteUrl($this->getEndpoint() . $endpoint, $body);
         return json_decode($response->getBody()->getContents());
     }
 
@@ -242,5 +254,15 @@ class BootstrapEndpoint
     private function deleteUrl($url, $body = [])
     {
         return $this->client()->delete($url, $body);
+    }
+
+    /**
+     * Get base endpoint
+     *
+     * @return string
+     */
+    public function getEndpoint()
+    {
+        return "https://{$this->domain}/{$this->version}/";
     }
 }

--- a/src/Endpoints/Schools.php
+++ b/src/Endpoints/Schools.php
@@ -13,6 +13,11 @@ class Schools extends BootstrapEndpoint
     public $achievements;
 
     /**
+     * @var AchievementsAttributes
+     */
+    public $achievementsAttributes;
+
+    /**
      * @var Attendance
      */
     public $attendance;
@@ -26,6 +31,11 @@ class Schools extends BootstrapEndpoint
      * @var Behaviours
      */
     public $behaviours;
+
+    /**
+     * @var BehavioursAttributes
+     */
+    public $behavioursAttributes;
 
     /**
      * @var Classes
@@ -121,7 +131,6 @@ class Schools extends BootstrapEndpoint
      * @var Events
      */
     public $events;
-
     /**
      * @var Doctors
      */

--- a/src/Endpoints/Schools.php
+++ b/src/Endpoints/Schools.php
@@ -177,6 +177,36 @@ class Schools extends BootstrapEndpoint
         $this->subjects               = new Subjects($token, $this->uri);
     }
 
+    public function updateDomain($domain)
+    {
+        $this->achievements->domain = $domain;
+        $this->achievementsAttributes->domain = $domain;
+        $this->assessment->domain = $domain;
+        $this->attendance->domain = $domain;
+        $this->attendanceSummaries->domain = $domain;
+        $this->behaviours->domain = $domain;
+        $this->behavioursAttributes->domain = $domain;
+        $this->classes->domain = $domain;
+        $this->contacts->domain = $domain;
+        $this->counts->domain = $domain;
+        $this->deletions->domain = $domain;
+        $this->doctors->domain = $domain;
+        $this->employees->domain = $domain;
+        $this->employeeAbsences->domain = $domain;
+        $this->events->domain = $domain;
+        $this->groups->domain = $domain;
+        $this->lessons->domain = $domain;
+        $this->lessonAttendance->domain = $domain;
+        $this->medicalConditions->domain = $domain;
+        $this->medicalEvents->domain = $domain;
+        $this->periods->domain = $domain;
+        $this->photos->domain = $domain;
+        $this->rooms->domain = $domain;
+        $this->students->domain = $domain;
+        $this->studentsPreAdmission->domain = $domain;
+        $this->subjects->domain = $domain;
+    }
+
     /**
      * Return all pending schools
      *

--- a/tests/MiscEndPointsRegionalDomainTest.php
+++ b/tests/MiscEndPointsRegionalDomainTest.php
@@ -1,0 +1,308 @@
+<?php
+
+class MiscEndPointsRegionalDomainTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Wonde\Endpoints\Schools
+     */
+    public $school;
+
+    private $token;
+
+    private $schoolId;
+
+    /**
+     * @var \Wonde\Client
+     */
+    private $client;
+
+    public function setUp()
+    {
+        ini_set('memory_limit', '3000M');
+        $this->token    = file_get_contents(__DIR__ . '/../.token');
+        $this->client   = new \Wonde\Client($this->token);
+        $this->schoolId = file_get_contents(__DIR__ . '/../.school');
+        $this->school   = $this->client->school($this->schoolId);
+
+        $schoolData = $this->client->schools->get($this->schoolId);
+        $this->school->updateDomain($schoolData->region->domain);
+    }
+
+    public function test_request_access()
+    {
+        $response = $this->client->requestAccess($this->schoolId);
+        $this->assertTrue($response->success);
+    }
+
+    public function test_revoke_access()
+    {
+        $response = $this->client->revokeAccess($this->schoolId);
+        $this->assertTrue($response->success);
+    }
+
+    public function test_single_school()
+    {
+        $school = $this->client->schools->get(file_get_contents(__DIR__ . '/../.school'));
+        $this->assertTrue($school instanceof stdClass);
+    }
+
+    public function tests_students()
+    {
+        $items = [];
+        foreach ($this->school->students->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function tests_attendance_summaries()
+    {
+        $items = [];
+        foreach ($this->school->attendanceSummaries->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function tests_employees()
+    {
+        $items = [];
+        foreach ($this->school->employees->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_contacts()
+    {
+        $items = [];
+        foreach ($this->school->contacts->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_subjects()
+    {
+        $items = [];
+        foreach ($this->school->subjects->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_rooms()
+    {
+        $items = [];
+        foreach ($this->school->rooms->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_groups()
+    {
+        $items = [];
+        foreach ($this->school->groups->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_classes()
+    {
+        $items = [];
+        foreach ($this->school->classes->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_events()
+    {
+        $items = [];
+        foreach ($this->school->events->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_medical_events()
+    {
+        $items = [];
+        foreach ($this->school->medicalEvents->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_medical_conditions()
+    {
+        $items = [];
+        foreach ($this->school->medicalConditions->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_periods()
+    {
+        $items = [];
+        foreach ($this->school->periods->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_lessons()
+    {
+        $items = [];
+        foreach ($this->school->lessons->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_achievements()
+    {
+        $items = [];
+        foreach ($this->school->achievements->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_achievements_attributes()
+    {
+        $items = [];
+        foreach ($this->school->achievementsAttributes->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_behaviour()
+    {
+        $items = [];
+        foreach ($this->school->behaviours->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_behaviour_attributes()
+    {
+        $items = [];
+        foreach ($this->school->behavioursAttributes->all() as $row) {
+            $items[] = $row;
+            $this->assertTrue($row instanceof stdClass);
+            $this->assertNotEmpty($row);
+        }
+        $this->assertTrue($items > 10);
+    }
+
+    public function test_delete_behaviour()
+    {
+        $response = $this->school->behaviours->delete('A1971302099');
+        $this->assertTrue($response instanceof stdClass);
+    }
+
+    public function test_delete_achievement()
+    {
+        $response = $this->school->achievements->delete('A125747323');
+        $this->assertTrue($response instanceof stdClass);
+    }
+
+    public function test_behaviour_post()
+    {
+        $array = [
+            'students'      => [
+                [
+                    'student_id'  => 'A1039521228',
+                    'role'        => 'AG',
+                    'action'      => 'COOL',
+                    'action_date' => '2016-04-01',
+                    'points'      => 200,
+                ],
+                [
+                    'student_id' => 'A870869351',
+                    'role'       => 'TA',
+                    'points'     => 2,
+                ],
+            ],
+            'employee_id'   => 'A1375078684',
+            'date'          => '2016-03-31',
+            'status'        => 'REV2',
+            'type'          => 'BULL',
+            'bullying_type' => 'B_INT',
+            'comment'       => 'Bulling incident',
+            'activity_type' => 'RE',
+            'location'      => 'CORR',
+            'time'          => 'LUN',
+        ];
+
+        try {
+            $response = $this->school->behaviours->create($array);
+        } catch ( \Wonde\Exceptions\ValidationError $error ) {
+            $errors = $error->getErrors();
+        }
+    }
+
+    public function test_achievement_post()
+    {
+        $array = [
+            'students'      => [
+                [
+                    'student_id' => 'A1039521228',
+                    'points'     => 200,
+                    'award'      => 'TROP',
+                    'award_date' => '2016-04-05',
+                ],
+            ],
+            'employee_id'   => 'A1375078684',
+            'date'          => '2016-04-04',
+            'type'          => 'NYPA',
+            'comment'       => 'A4',
+            'activity_type' => 'RE',
+        ];
+
+        try {
+            $response = $this->school->achievements->create($array);
+        } catch ( \Wonde\Exceptions\ValidationError $error ) {
+            $errors = $error->getErrors();
+        }
+    }
+}
+


### PR DESCRIPTION
**#10 Add support for regional domains**
Regional domains have alternate wonde api endpoints. e.g: `https://api-ap-southeast-2.wonde.com/v1.0/`

This pull request allows the integrating code to query the domain from a school and then update all API's associated with the school to the updated region domain.

It deprecates the endpoint constant that is currently in use in favour of a more easily modified endpoint for the various API calls.