### PR TITLE
Make updateDomain fluent

### DIFF
--- a/src/Endpoints/Schools.php
+++ b/src/Endpoints/Schools.php
@@ -136,12 +136,12 @@ class Schools extends BootstrapEndpoint
      * @var Events
      */
     public $events;
-    
+
     /**
      * @var Doctors
      */
     public $doctors;
-    
+
     /**
      * @var Exclusions
      */
@@ -226,6 +226,8 @@ class Schools extends BootstrapEndpoint
         $this->students->domain = $domain;
         $this->studentsPreAdmission->domain = $domain;
         $this->subjects->domain = $domain;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Allows us to adjust the domain in a fluent way, for example:

```php
$employees = $instance
    ->school($organisation->wonde_id)
    ->updateDomain('api-ap-southeast-2.wonde.com')
    ->employees
    ->all(['employment_details', 'contact_details']);
```