### PR TITLE
Add PHP 8.2 support

### DIFF
--- a/src/Endpoints/BootstrapEndpoint.php
+++ b/src/Endpoints/BootstrapEndpoint.php
@@ -38,7 +38,7 @@ class BootstrapEndpoint
     /**
      * @var string
      */
-    private $logPath = '';
+    protected $logPath = '';
 
     /**
      * BootstrapEndpoint constructor.

--- a/src/Endpoints/Schools.php
+++ b/src/Endpoints/Schools.php
@@ -159,14 +159,9 @@ class Schools extends BootstrapEndpoint
     public $exclusions;
 
     /**
-     * @var string
-     */
-    private $logPath = '';
-
-    /**
      * Schools constructor.
      *
-     * @param string $uri
+     *
      */
     public function __construct($token, $id = false, $logPath = '')
     {

--- a/src/ResultIterator.php
+++ b/src/ResultIterator.php
@@ -19,10 +19,6 @@ class ResultIterator extends BootstrapEndpoint implements \Iterator
      */
     private $meta;
 
-    /**
-     * @var string
-     */
-    private $logPath = '';
 
     public function __construct($givenArray, $token, $logPath = '')
     {


### PR DESCRIPTION
Addresses errors on PHP 8.2.

`Endpoints/Assessment.php` does not define its own  `$log` property nor does it have visibility on the `$log` defined in `Endpoints/BootstrapEndpoint.php`.

This inadvertently resulted in dynamic property creation which is not allowed in newer version of PHP.
 
