### PR TITLE
Lesson Attendance Write Mark

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -543,6 +543,7 @@ $attendance = new \Wonde\Writeback\LessonAttendanceRecord();
 $attendance->setStudentId('STUDENT_ID_GOES_HERE');
 $attendance->setLessonId('LESSON_ID_GOES_HERE');
 $attendance->setAttendanceCodeId('ATTENDANCE_CODE_ID_GOES_HERE');
+$attendance->setComment('Comment here.');
 
 // Add attendance mark to register
 $register->add($attendance);

--- a/src/Writeback/LessonAttendanceRecord.php
+++ b/src/Writeback/LessonAttendanceRecord.php
@@ -20,6 +20,11 @@ class LessonAttendanceRecord
     private $attendance_code_id;
 
     /**
+     * @var string
+     */
+    private $comment;    
+
+    /**
      * Set student id
      *
      * @param string $date
@@ -114,7 +119,33 @@ class LessonAttendanceRecord
             'attendance_code_id' => $this->getAttendanceCodeId()
         ];
 
+        $comment = $this->getComment();
+
+        if ( ! empty($comment)) {
+            $required['comment'] = $comment;
+        }        
+
         return $required;
     }
+
+    /**
+     * Get the comment value
+     *
+     * @return string
+     */
+    public function getComment()
+    {
+        return $this->comment;
+    }
+
+    /**
+     * Set the comment value
+     *
+     * @param string $comment
+     */
+    public function setComment($comment)
+    {
+        $this->comment = $comment;
+    }    
 
 }


### PR DESCRIPTION
The pull request brings the ability to writeback a comment for the POST Lesson Attendance entity. This is currently available in the Session Attendance POST entity so I have simply copied over the functionality across and updated the Readme.

The ability for Comments to be written back for Lesson Attendance is mentioned in the Wonde API Docs. https://docs.wonde.com/docs/api/sync/#post-lesson-attendance